### PR TITLE
feat: Add PR and Release builds via cloudbuild

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,8 @@
+.git
+tmp/
+__pycache__/
+*.pyc
+helm/
+tmp
+node_modules
+.virt

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ bin
 *.swp
 *.swo
 *~
+
+# goreleaser
+dist/*
+# gcp things
+gopath/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    id: ds-operator
+    goos:
+      - linux
+    goarch:
+      - amd64
+dockers:
+  -
+    goos: linux
+    goarch: amd64
+    goarm: ''
+    builds:
+      - ds-operator
+    image_templates:
+      - "{{.Env.IMG}}"
+    dockerfile: build/Dockerfile
+    build_flag_templates:
+    - "--label=org.label-schema.schema-version=1.0"
+    - "--label=org.label-schema.version={{.Version}}"
+    - "--label=org.label-schema.name={{.ProjectName}}"
+archives:
+  - replacements:
+      linux: Linux
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+release:
+  github:
+    owner: ForgeRock
+    name: ds-operator
+  prerelease: auto
+  name_template: "{{.ProjectName}}-v{{.Version}}"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+USER nonroot:nonroot
+ENTRYPOINT ["/ds-opertor"]

--- a/cloudbuild.release.yaml
+++ b/cloudbuild.release.yaml
@@ -1,0 +1,25 @@
+steps:
+# Setup the workspace so we have a viable place to point GOPATH at.
+- name: gcr.io/cloud-builders/go
+  env: ['PROJECT_ROOT=github.com/ForgeRock/ds-operator']
+  args: ['env']
+
+- name: gcr.io/cloud-builders/go                          
+  env: ['PROJECT_ROOT=github.com/ForgeRock/ds-operator'] 
+  args: ['test', './...']                                           
+
+- name: goreleaser/goreleaser
+  entrypoint: /bin/sh
+  dir: gopath/src/github.com
+  env: ['GOPATH=/workspace/gopath']
+  # we "create" the tag because cloud build doesn't pull the tags, just commit
+  args: ['-c', 'cd ForgeRock/ds-operator && git tag $TAG_NAME && IMG=gcr.io/$PROJECT_ID/ds-operator:$TAG_NAME make release' ]
+  secretEnv: ['GITHUB_TOKEN']
+
+secrets:
+- kmsKeyName: projects/engineering-devops/locations/global/keyRings/engineering-devops/cryptoKeys/github-key
+  secretEnv:
+    GITHUB_TOKEN: |
+      CiQAWHysaumBCi7eM+fysjiJWzP2vFq50c6h78JyNyyS3RJSQlASUQBqP6GPGGhZy6CwJOwzTvLf
+      jhnEY3cT3uM0RunKcS1wXK+7q93BAmi3UsV7z2HWf3/ppWiwZTEepEd4X1S9NgVEQPTZuQ+ZJbdN
+      q2BJRn6SVA==

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,23 @@
+steps:
+  # Setup the workspace so we have a viable place to point GOPATH at.
+  - name: gcr.io/cloud-builders/go
+    env: ['PROJECT_ROOT=github.com/ForgeRock/ds-operator']
+    args: ['env']
+
+  - name: gcr.io/cloud-builders/go
+    env: ['PROJECT_ROOT=github.com/ForgeRock/ds-operator']
+    args: ['test', './...']
+
+  - name: goreleaser/goreleaser
+    entrypoint: /bin/sh
+    dir: gopath/src/github.com
+    env: ['GOPATH=/workspace/gopath']
+    args: ['-c', 'cd ForgeRock/ds-operator && make build PR_NUMBER=$_PR_NUMBER']
+    secretEnv: ['GITHUB_TOKEN']
+secrets:
+  - kmsKeyName: projects/engineering-devops/locations/global/keyRings/engineering-devops/cryptoKeys/github-key
+    secretEnv:
+      GITHUB_TOKEN: |
+        CiQAWHysaumBCi7eM+fysjiJWzP2vFq50c6h78JyNyyS3RJSQlASUQBqP6GPGGhZy6CwJOwzTvLf
+        jhnEY3cT3uM0RunKcS1wXK+7q93BAmi3UsV7z2HWf3/ppWiwZTEepEd4X1S9NgVEQPTZuQ+ZJbdN
+        q2BJRn6SVA==

--- a/hack/install-goreleaser.sh
+++ b/hack/install-goreleaser.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+                                                                                                                                           
+case "${OSTYPE}" in                                                                                                                        
+    "darwin"*) os="Darwin";;                                                                                                               
+    "linux"*) os="Linux";;                                                                                                                 
+esac                                                                                                                                       
+                                                                                                                                           
+if ! curl -o /tmp/goreleaser.tar.gz -L "https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_${os}_x86_64.tar.gz"; 
+then
+    echo "failed to download go releaser"
+    exit 1;
+fi
+if ! mkdir /tmp/releaser && tar xf /tmp/goreleaser.tar.gz -C /tmp/releaser;
+then
+    echo "failed to extract go releaser"
+    exit 1;
+fi
+if ! install /tmp/goreleaser bin/goreleaser; 
+then
+    echo "failed to install to bin/"
+    exit 1;
+fi
+if ! rm -rf /tmp/{releaser,goreleaser.tar.gz};
+then
+    echo "failed to cleanup"
+    exit 1;
+fi


### PR DESCRIPTION
Adds `goreleaser` to do docker builds on PRs and for releases (tags) as
well as generate release notes and "create GitHub Release". Uses GCP
Cloud Build as CI.