### PR TITLE
Dev

### DIFF
--- a/controllers/passwords.go
+++ b/controllers/passwords.go
@@ -13,41 +13,49 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-/// Manages ldap service account passwords
+// PasswordCheckTimeSeconds is the number of seconds between password checks. The first time through will trigger an immediate check.
+// This is to avoid overloading the directory.
+const PasswordCheckTimeSeconds = 300
 
+/// Manages ldap service account passwords in Spec.Passwords
 func (r *DirectoryServiceReconciler) updatePasswords(ctx context.Context, ds *directoryv1alpha1.DirectoryService, ldap *ldap.DSConnection) error {
 	log := r.Log
 
-	if ds.Status.ServiceAccountPasswordsUpdatedTime != 0 {
-		// TODO: Do we want to trigger a password update if a secret changes?
-		log.V(5).Info("Service account passwords already updated, nothing to do")
+	now := time.Now().Unix()
+	elapsed := now - ds.Status.ServiceAccountPasswordsUpdatedTime
+
+	// if it is to soon, skip the check so we are nice to the directory
+	if elapsed < PasswordCheckTimeSeconds {
 		return nil
 	}
-	log.Info("Updating service account passwords")
-
 	// for each password
 	for key, account := range ds.Spec.Passwords {
 		// skip any internal accounts as they are managed on boot by the ds image
 		if key == "uid=admin" || key == "uid=monitor" {
 			continue
 		}
-		log.Info("Updating service account password", "dn", key, "secretName", account.SecretName, "key", account.Key)
-		// get the secret with the password
+		log.V(5).Info("Updating service account password", "dn", key, "secretName", account.SecretName, "key", account.Key)
+		// get the secret containing the password
 		pw, err := r.lookupSecret(ctx, ds.Namespace, ds.SecretNameForDN(key), account.Key)
 		if err != nil {
 			log.Error(err, "Can't find secret containing the password", "account", key, "secretName", account.SecretName)
 			return err
 		}
+		// First check to see if we even need to change the password. It may be fine
+		if ldap.BindPassword(key, pw) == nil {
+			log.V(5).Info("Current password for DN is OK", "dn", key)
+			continue
+		}
+		// Bind above failed, so lets try to change it:
 		if err := ldap.UpdatePassword(key, pw); err != nil {
 			log.Error(err, "Failed to update the password", "dn", key)
 			return err
 		}
 		log.Info("Updated password", "dn", key)
 	}
-	// if we get to here we have updated the passwords OK
-	ds.Status.ServiceAccountPasswordsUpdatedTime = time.Now().Unix()
+	// if we get to here we have updated all passwords OK
+	ds.Status.ServiceAccountPasswordsUpdatedTime = now
 
-	// todo: Update the status so we dont do this everytime
 	return nil
 }
 

--- a/hack/ds.yaml
+++ b/hack/ds.yaml
@@ -4,7 +4,7 @@ kind: DirectoryService
 metadata:
   name: ds-idrepo
 spec:
-  image: gcr.io/forgeops-public/ds-idrepo:dab61faf
+  image: gcr.io/forgeops-public/ds-idrepo:7.1-dev
   # The number of DS servers in the topology
   replicas: 1
   # The resources assigned to each DS pod

--- a/pkg/ldap/client.go
+++ b/pkg/ldap/client.go
@@ -65,6 +65,19 @@ func (ds *DSConnection) getEntry(dn string) (*ldap.Entry, error) {
 	return res.Entries[0], err
 }
 
+// BindPassword tries to bind as the DN with the password. This is used to test the password to see if we need to change it.
+// Return nil if the password is OK, err otherwise
+func (ds *DSConnection) BindPassword(DN, password string) error {
+	ds.Log.V(2).Info("ldap client - BIND", "DN", DN)
+	// get a new connection. We cant do this with th existing connection as it would unbind us from the admin account..
+	tldap, err := ldap.DialURL(ds.URL, ldap.DialWithTLSConfig(&tls.Config{InsecureSkipVerify: true}))
+	defer tldap.Close()
+	if err != nil {
+		return err
+	}
+	return tldap.Bind(DN, password)
+}
+
 // UpdatePassword changes the password for the user identified by the DN. This is done as an administrative password change
 // The old password is not required.
 func (ds *DSConnection) UpdatePassword(DN, newPassword string) error {


### PR DESCRIPTION
The ds-operator will now check and reconcile the service account passwords every 5
min (or immeditialy on first deploy).

The existing password is first checked against the secret, and only if
it fails will the operator attempt to change the password.

This will sync any password changes every 5 minutes. Note that
that many other applications may need to be restarted on a password
change, especially if they mount the secret containing the password.

In general, it is not recommended to frequently change or rotate the passwords.
