### PR TITLE
Change the names of artifacts created by goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,7 @@ dockers:
 archives:
   - replacements:
       linux: Linux
+    name_template:  "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Change the names of artifacts created by goreleaser
Drops the "version" from the artifact's name.
This change makes it easier to obtain our binaries using automation (e.a. in a CICD environment).  

This is the new artifact's name:
![image](https://user-images.githubusercontent.com/22987396/105935863-98d3ff80-6007-11eb-8e47-c59946f9b1ff.png)
