### PR TITLE
fix: Update RBAC rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install run test uninstall deploy manifest fmt vet generate docker-build release
 # Image URL to use all building/pushing image targets
-DEFAULT_IMG = gcr.io/engineering-devops/ds-operator
+DEFAULT_IMG = gcr.io/forgeops-public/ds-operator
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 #CRD_OPTIONS ?= "crd:trivialVersions=false"
 # This will work on kube versions 1.16+. We want the CRD OpenAPI validation features in v1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install run test uninstall deploy manifest fmt vet generate docker-build release
 # Image URL to use all building/pushing image targets
-DEFAULT_IMG = gcr.io/forgeops-public/ds-operator
+DEFAULT_IMG = gcr.io/engineering-devops/ds-operator
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 #CRD_OPTIONS ?= "crd:trivialVersions=false"
 # This will work on kube versions 1.16+. We want the CRD OpenAPI validation features in v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: gcr.io/engineering-devops/ds-operator
+  newName: gcr.io/forgeops-public/ds-operator
   newTag: latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   - services
   verbs:
@@ -81,3 +89,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/directoryservice_controller.go
+++ b/controllers/directoryservice_controller.go
@@ -56,15 +56,15 @@ var (
 // +kubebuilder:rbac:groups=directory.forgerock.io,resources=directoryservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=directory.forgerock.io,resources=directoryservices/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets;services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;create
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile loop for DS controller
 func (r *DirectoryServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// todo: new lib does not need this...
-	// ctx := context.Background()
 	// This adds the log data to every log line
 	var log = r.Log.WithValues("directoryservice", req.NamespacedName)
 


### PR DESCRIPTION
Update the rbac to include events and volumesnapshots
Set the default docker repo to forgeops-public