### PR TITLE
Revert "Use custom image for DS deployment"

### DIFF
--- a/hack/ds.yaml
+++ b/hack/ds.yaml
@@ -7,8 +7,7 @@ metadata:
     app.kubernetes.io/name: ds
     app.kubernetes.io/part-of: forgerock
 spec:
-  # TODO; This test image is for PEM keystore support
-  image: gcr.io/forgeops-public/ds-idrepo/ds-idrepo:dev-temp
+  image: gcr.io/forgeops-public/ds-idrepo:dev
 
   # Optional - uses K8S default behavior if not provided
   # imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**This can be merged when PEM support has made it to the official DS image**

This reverts commit f2a528319fb3edd231efa1c5c292ed337ba276d1.