### PR TITLE
feat: Implement Topology Spread constraints

### DIFF
--- a/controllers/sts.go
+++ b/controllers/sts.go
@@ -241,8 +241,8 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 					TopologySpreadConstraints: []v1.TopologySpreadConstraint{
 						{
 							MaxSkew:           1,
-							TopologyKey:       "zone",
-							WhenUnsatisfiable: "ScheduleAnyway",
+							TopologyKey:       "topology.kubernetes.io/zone",
+							WhenUnsatisfiable: v1.ScheduleAnyway,
 							LabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"app.kubernetes.io/instance": ds.Name,
@@ -278,7 +278,7 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 							Name:            "ds",
 							Image:           ds.Spec.Image,
 							ImagePullPolicy: ds.Spec.ImagePullPolicy,
-							Args:            []string{"start"},
+							Args:            []string{"start-ds"},
 							VolumeMounts:    volumeMounts,
 							Resources:       ds.DeepCopy().Spec.Resources,
 							Env:             envVars,

--- a/controllers/sts.go
+++ b/controllers/sts.go
@@ -234,33 +234,18 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 			Replicas:    ds.Spec.Replicas,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: createLabels(ds.Name, map[string]string{
-						"affinity": "directory", // for anti-affinity
-					}),
+					Labels: createLabels(ds.Name, nil),
 				},
 				Spec: v1.PodSpec{
-					// We use anti affinity to spread the pods out over host node
-					Affinity: &v1.Affinity{
-						// NodeAffinity:    &v1.NodeAffinity{},
-						// PodAffinity:     &v1.PodAffinity{},
-						PodAntiAffinity: &v1.PodAntiAffinity{
-							//RequiredDuringSchedulingIgnoredDuringExecution:  []v1.PodAffinityTerm{},
-							PreferredDuringSchedulingIgnoredDuringExecution: []v1.WeightedPodAffinityTerm{
-								{
-									Weight: 100,
-									PodAffinityTerm: v1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchLabels: map[string]string{},
-											MatchExpressions: []metav1.LabelSelectorRequirement{
-												{
-													Key:      "affinity",
-													Operator: "In",
-													Values:   []string{"directory"},
-												},
-											},
-										},
-										TopologyKey: "kubernetes.io/hostname",
-									},
+					// Spread the DS pods across zones if possible. If not possible, schedule anyways
+					TopologySpreadConstraints: []v1.TopologySpreadConstraint{
+						{
+							MaxSkew:           1,
+							TopologyKey:       "zone",
+							WhenUnsatisfiable: "ScheduleAnyway",
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"app.kubernetes.io/instance": ds.Name,
 								},
 							},
 						},

--- a/hack/ds-kustomize/ds.yaml
+++ b/hack/ds-kustomize/ds.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   # TODO; This test image is for PEM keystore support
   # image: gcr.io/forgeops-public/ds-idrepo/ds-idrepo:dev-temp
-  image: gcr.io/forgeops-public/ds:dev
+  image: gcr.io/forgeops-public/ds:7.2-dev
   imagePullPolicy: IfNotPresent
 
   # The number of DS servers in the topology

--- a/hack/ds-kustomize/ds.yaml
+++ b/hack/ds-kustomize/ds.yaml
@@ -44,12 +44,12 @@ spec:
   # Optional - Configures the operator to automatically take snapshots
   # You must be using a CSI volume driver.
   snapshots:
-    enabled: false
+    enabled: true
     # Take a snapshot every N minutes. The number here is VERY low for testing.
     # On a production cluster, you should set this to something higher (30 minutes).
-    periodMinutes: 2
+    periodMinutes: 10
     # Keep this many snapshots. Older snapshots will be deleted
-    snapshotsRetained: 2
+    snapshotsRetained: 3
     # This defaults to ds-snapshot-class if not specified
     volumeSnapshotClassName: ds-snapshot-class
 

--- a/hack/ds.yaml
+++ b/hack/ds.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: ds
     app.kubernetes.io/part-of: forgerock
 spec:
-  image: gcr.io/forgeops-public/ds:dev
+  image: gcr.io/forgeops-public/ds:7.2-dev
 
   # Optional - uses K8S default behavior if not provided
   # imagePullPolicy: IfNotPresent

--- a/hack/secrets.yaml
+++ b/hack/secrets.yaml
@@ -18,7 +18,6 @@ items:
   kind: Secret
   metadata:
     name: ds
-    namespace: default
   type: Opaque
 - apiVersion: v1
   data:
@@ -28,7 +27,6 @@ items:
   kind: Secret
   metadata:
     name: ds-env-secrets
-    namespace: default
   type: Opaque
 - apiVersion: v1
   data:
@@ -37,7 +35,6 @@ items:
   kind: Secret
   metadata:
     name: ds-passwords
-    namespace: default
   type: Opaque
 - apiVersion: v1
   data:
@@ -47,5 +44,4 @@ items:
   kind: Secret
   metadata:
     name: platform-ca
-    namespace: default
   type: Opaque

--- a/tests/ds-snapshots.yaml
+++ b/tests/ds-snapshots.yaml
@@ -16,7 +16,7 @@ spec:
     limits:
       memory: 1024Mi
   volumeClaimSpec:
-    storageClassName: fast
+    storageClassName: standard-rwo
     accessModes: [ "ReadWriteOnce" ]
     resources:
       requests:


### PR DESCRIPTION
Topology spreads are GA in 1.19, and are simpler/more flexible that affinity

refs: CLOUD-3375