### PR TITLE
refactor: Configure support for Multi-cluster deployments with CloudDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once the ds-operator has been installed, you can deploy an instance of the direc
 Below is a sample deployment session
 
 ```bash
-kubectl apply -k hack/ds-kustomize.yaml
+kubectl apply -k hack/ds-kustomize
 
 # pw.sh script will retrieve the uid=admin password:
 ./hack/pw.sh
@@ -251,22 +251,15 @@ spec:
 DS can be configured across multiple clusters located in the same or different geographical regions for high availability or DR purposes.
 DS pods need to be uniquely identifiable within the topology  across all clusters.  There are 2 sample solutions documented in forgeops:
 
-[MCS(GKE Multi-cluster Services)](https://github.com/ForgeRock/forgeops/blob/master/etc/multi-region/mcs/docs/article.adoc)
+[CloudDNS(Recommended solution)](https://github.com/ForgeRock/forgeops/tree/master/etc/multi-cluster/clouddns)  
+[MCS(GKE Multi-cluster Services)](https://github.com/ForgeRock/forgeops/blob/master/etc/multi-region/mcs/docs/article.adoc)  
 [kubedns](https://github.com/ForgeRock/forgeops/blob/master/etc/multi-region/kubedns/doc/article.adoc)
 
-
 To enable multi-cluster:
-* configure a list of unique identifiers(`clusterTopology`) for each cluster.
-* provide the current cluster's identifier(`clusterIdentifier`). `clusterIdentifier` must match 1 of the names in `clusterTopology`.
+* Configure a list of unique identifiers(`clusterTopology`) for each cluster.
+* Provide the current cluster's identifier(`clusterIdentifier`). `clusterIdentifier` must match 1 of the names in `clusterTopology`.
+* Configure the solution option if using a alternative solution to the CloudDNS recommended option.
 
-**MCS**
-If using MCS set `mcsEnable` to `true`.  The `clusterTopology` names need to match the cluster membership names used when
-registering the cluster to the hub as specified in the docs. These help to define the bootstrap servers.  E.g. deploying idrepo to cluster 'eu' would look like:
-
-`<hostname>.<uniqueidentifier/membershipname>.<servicename>.svc.clusterset.local:8989`
-```
-Bootstrap replication server(s) : ds-idrepo-0.eu.ds-idrepo.prod.svc.clusterset.local:8989,ds-idrepo-0.us.ds-idrepo.prod.svc.clusterset.local:8989
-```
 Spec:
 
 ```yaml
@@ -274,7 +267,7 @@ Spec:
   multiCluster:
     clusterTopology: "eu,us"
     clusterIdentifier: "eu"
-    mcsEnable: true
+    solution: "clouddns"
 ```
 
 ## Backup and Restore to LDIF (Preview)

--- a/api/v1alpha1/directoryservice_types.go
+++ b/api/v1alpha1/directoryservice_types.go
@@ -52,7 +52,7 @@ type DirectoryServiceSpec struct {
 	// The account secrets. The key is the DN of the secret (example, uid=admin)
 	Passwords map[string]DirectoryPasswords `json:"passwords"`
 
-	// Certificates needed for direcotory operation.
+	// Certificates needed for directory operation.
 	Certificates DirectoryCertificates `json:"certificates"`
 
 	// +kubebuilder:validation:Required
@@ -186,13 +186,15 @@ type DirectoryServiceList struct {
 
 // MultiCluster enables MCS and configures identifiers for multiple multi-cluster solutions
 type MultiCluster struct {
-	// +kubebuilder:default:=false
-	McsEnabled bool `json:"mcsEnabled,omitempty"`
 	// ClusterTopology is a comma separate string of identifiers for each cluster e.g. "europe,us"
 	// +kubebuilder:validation:required
-	ClusterTopology string `json:"clusterTopology"`
+	ClusterTopology 	string `json:"clusterTopology"`
 	// +kubebuilder:validation:required
-	ClusterIdentifier string `json:"clusterIdentifier"`
+	ClusterIdentifier 	string `json:"clusterIdentifier"`
+	// Solution defines the multi-cluster solution used.
+	// +kubebuilder:validation:Enum=clouddns;mcs;kubens	
+	// +kubebuilder:default:=clouddns
+	Solution 			string `json:"solution,omitempty"`
 }
 
 func init() {

--- a/config/crd/bases/directory.forgerock.io_directoryobjects.yaml
+++ b/config/crd/bases/directory.forgerock.io_directoryobjects.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: directoryobjects.directory.forgerock.io
 spec:

--- a/config/crd/bases/directory.forgerock.io_directoryservices.yaml
+++ b/config/crd/bases/directory.forgerock.io_directoryservices.yaml
@@ -39,7 +39,7 @@ spec:
             description: DirectoryServiceSpec defines the desired state of DirectoryService
             properties:
               certificates:
-                description: Certificates needed for direcotory operation.
+                description: Certificates needed for directory operation.
                 properties:
                   masterSecretName:
                     default: ds-master-keypair
@@ -82,9 +82,14 @@ spec:
                     description: ClusterTopology is a comma separate string of identifiers
                       for each cluster e.g. "europe,us"
                     type: string
-                  mcsEnabled:
-                    default: false
-                    type: boolean
+                  solution:
+                    default: clouddns
+                    description: Solution defines the multi-cluster solution used.
+                    enum:
+                    - clouddns
+                    - mcs
+                    - kubens
+                    type: string
                 required:
                 - clusterIdentifier
                 - clusterTopology

--- a/controllers/directoryservice_controller.go
+++ b/controllers/directoryservice_controller.go
@@ -115,8 +115,10 @@ func (r *DirectoryServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	svcName := ds.Name
 
 	if ds.Spec.MultiCluster.ClusterTopology != "" {
-		clusterIdentifier = "-" + ds.Spec.MultiCluster.ClusterIdentifier
-		svcName = svcName + clusterIdentifier
+		if ds.Spec.MultiCluster.Solution == "kubens" {
+			clusterIdentifier = "-" + ds.Spec.MultiCluster.ClusterIdentifier
+			svcName = svcName + clusterIdentifier
+		}
 	}
 
 	//// SECRETS ////

--- a/controllers/sts.go
+++ b/controllers/sts.go
@@ -77,9 +77,16 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 	// var initArgs []string // args provided to the init container
 	var advertisedListenAddress = fmt.Sprintf("$(POD_NAME).%s", ds.Name)
 
+	// Enable Multi-cluster Services(MCS)
+	var mcsEnabled = false
+
 	if ds.Spec.MultiCluster.ClusterTopology != "" {
 		// Remove AdvertisedListenAddress default value so it can be configured by multi-cluster settings
 		advertisedListenAddress = ""
+	}
+
+	if ds.Spec.MultiCluster.Solution == "mcs" {
+		mcsEnabled = true
 	}
 
 	var volumeMounts = []v1.VolumeMount{
@@ -209,7 +216,7 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 		},
 		{
 			Name:  "MCS_ENABLED",
-			Value: strconv.FormatBool(ds.Spec.MultiCluster.McsEnabled),
+			Value: strconv.FormatBool(mcsEnabled),
 		},
 		{
 			Name:  "DS_SET_UID_ADMIN_AND_MONITOR_PASSWORDS",

--- a/hack/ds-kustomize/ds.yaml
+++ b/hack/ds-kustomize/ds.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: forgerock
 spec:
   image: gcr.io/forgeops-public/ds:7.2-dev
-  imagePullPolicy: IfNotPresent
+  imagePullPolicy: Always
 
   # The number of DS servers in the topology
   replicas: 1
@@ -91,14 +91,18 @@ spec:
   scriptConfigMapName: ds-script-config
 
 
-  #### Multi-cluster ####
+  ### Multi-cluster (Google Cloud only)####
+  # clusterTopology and clusterIdentifier are required in multi-cluster solutions to ensure DS is configured uniquely across clusters.
+  # clusterTopology - list of identifiers for the each cluster used to determine the bootstrap servers.
+  # Bootstrap servers example output in a multi-cluster MCS environment:
+  # Bootstrap replication server(s) : ds-idrepo-0.eu.ds-idrepo-eu.prod.svc.clusterset.local:8989,ds-idrepo-0.us.ds-idrepo.prod.svc.clusterset.local:8989
+  # Bootstrap servers example output in a multi cluster kubens environment:
+  # Bootstrap replication server(s) : ds-idrepo-0.eu.ds-idrepo-eu.prod.svc.cluster.local:8989,ds-idrepo-0.us.ds-idrepo.prod.svc.cluster.local:8989
+  # Bootstrap servers example output in a multi cluster clouddns environment:
+  # Bootstrap replication server(s) : ds-idrepo-0.ds-idrepo.prod.svc.eu:8989,ds-idrepo-0.ds-idrepo.prod.svc.us:8989
   # multiCluster:
-    ## clusterTopology and clusterIdentifier are required in multi-cluster solutions make DS unique across clusters.
-    ## clusterTopology - list of identifiers for the each cluster used to determine the bootstrap servers.
-    ## Bootstrap servers example output in a multi-region MCS environment:
-    ## Bootstrap replication server(s) : ds-idrepo-0.eu.ds-idrepo-eu.prod.svc.clusterset.local:8989,ds-idrepo-0.us.ds-idrepo.prod.svc.clusterset.local:8989
     # clusterTopology: "eu,us"
-    ## clusterIdentifier - current clusters identifier.  Must match 1 of the identifiers in clusterTopology
+    # Current clusters identifier.  Must match 1 of the identifiers in clusterTopology
     # clusterIdentifier: "eu"
-    ## Enable MCS(Googles Multi-cluster Services).  Not required for kubedns solution
-    # mcsEnabled: true
+    # Multi-cluster solution to use. Defaults to clouddns
+    # solution: "clouddns"


### PR DESCRIPTION
Configure server identifiers to work with the CloudDNS for GKE Multi-cluster solution.
Ensure code supports all 3 Multi-cluster solutions.
Updated readme and comments.

ref: CLOUD-3347