### PR TITLE
Refactor: Add env spec for Environment Variable declaration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,34 +247,34 @@ spec:
 ```
 
 ## Multi-cluster (Preview)
+ 
+DS can be configured across multiple clusters located in the same or different geographical regions for high availability or DR purposes(currently Google Cloud only).
+DS pods need to be uniquely identifiable within the topology  across all clusters.  We describe using CloudDNS for GKE 
+to handle this.  See the setup documentation below:
 
-DS can be configured across multiple clusters located in the same or different geographical regions for high availability or DR purposes.
-DS pods need to be uniquely identifiable within the topology  across all clusters.  There are 2 sample solutions documented in forgeops:
+[CloudDNS for GKE doc](https://github.com/ForgeRock/forgeops/blob/master/etc/multi-cluster/clouddns/README.md)
 
-[MCS(GKE Multi-cluster Services)](https://github.com/ForgeRock/forgeops/blob/master/etc/multi-region/mcs/docs/article.adoc)
-[kubedns](https://github.com/ForgeRock/forgeops/blob/master/etc/multi-region/kubedns/doc/article.adoc)
-
-
-To enable multi-cluster:
-* configure a list of unique identifiers(`clusterTopology`) for each cluster.
-* provide the current cluster's identifier(`clusterIdentifier`). `clusterIdentifier` must match 1 of the names in `clusterTopology`.
-
-**MCS**
-If using MCS set `mcsEnable` to `true`.  The `clusterTopology` names need to match the cluster membership names used when
-registering the cluster to the hub as specified in the docs. These help to define the bootstrap servers.  E.g. deploying idrepo to cluster 'eu' would look like:
-
-`<hostname>.<uniqueidentifier/membershipname>.<servicename>.svc.clusterset.local:8989`
-```
-Bootstrap replication server(s) : ds-idrepo-0.eu.ds-idrepo.prod.svc.clusterset.local:8989,ds-idrepo-0.us.ds-idrepo.prod.svc.clusterset.local:8989
-```
-Spec:
+To enable multi-cluster, configure the following environment variables in the custom resource.  
+* DS_GROUP_ID must contain the cluster identifier as described in the CloudDNS docs(e.g. "eu" for EU cluster)  
+* DS_BOOTSTRAP_REPLICATION_SERVERS
 
 ```yaml
-  #### Multi-cluster ####
-  multiCluster:
-    clusterTopology: "eu,us"
-    clusterIdentifier: "eu"
-    mcsEnable: true
+  env:
+    - name: DS_GROUP_ID
+      value: ""
+    - name: DS_BOOTSTRAP_REPLICATION_SERVERS
+      value: ""
+```
+
+Example env configuration for ds-idrepo on EU cluster:
+
+CloudDNS:
+```yaml
+  env:
+    - name: DS_GROUP_ID
+      value: "EU"
+    - name: DS_BOOTSTRAP_REPLICATION_SERVERS
+      value: "ds-idrepo-0.ds-idrepo.prod.svc.eu:8989,ds-idrepo-0.ds-idrepo.prod.svc.us:8989"
 ```
 
 ## Backup and Restore to LDIF (Preview)

--- a/api/v1alpha1/directoryservice_types.go
+++ b/api/v1alpha1/directoryservice_types.go
@@ -40,6 +40,10 @@ type DirectoryServiceSpec struct {
 	// +kubebuilder:validation:Enum=Never;IfNotPresent;Always
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
+	// Env vars
+	// +kubebuilder:validation:Optional
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
 	// GroupID is the value used to identify this group of directory servers (default: "default")
 	// This field can be set to $(POD_NAME) to allocate each ds server to its own group.
 	// Most users do not need to change this field.

--- a/config/crd/bases/directory.forgerock.io_directoryobjects.yaml
+++ b/config/crd/bases/directory.forgerock.io_directoryobjects.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: directoryobjects.directory.forgerock.io
 spec:

--- a/config/crd/bases/directory.forgerock.io_directoryservices.yaml
+++ b/config/crd/bases/directory.forgerock.io_directoryservices.yaml
@@ -55,6 +55,109 @@ spec:
                 - sslSecretName
                 - truststoreSecretName
                 type: object
+              env:
+                description: Env vars
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previous defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                        $$(VAR_NAME). Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               groupID:
                 default: default
                 description: 'GroupID is the value used to identify this group of

--- a/hack/ds-kustomize/ds.yaml
+++ b/hack/ds-kustomize/ds.yaml
@@ -20,6 +20,13 @@ spec:
     limits:
       memory: 1024Mi
 
+  # env:
+    # Required for multi-cluster deployments
+    # - name: DS_GROUP_ID
+    #   value: ""
+    # - name: DS_BOOTSTRAP_REPLICATION_SERVERS
+    #   value: ""
+
 # The volume spec for the DS data. This is the same as the Kubernetes PVC volume spec.
   volumeClaimSpec:
     storageClassName: fast
@@ -89,16 +96,3 @@ spec:
 
 
   scriptConfigMapName: ds-script-config
-
-
-  #### Multi-cluster ####
-  # multiCluster:
-    ## clusterTopology and clusterIdentifier are required in multi-cluster solutions make DS unique across clusters.
-    ## clusterTopology - list of identifiers for the each cluster used to determine the bootstrap servers.
-    ## Bootstrap servers example output in a multi-region MCS environment:
-    ## Bootstrap replication server(s) : ds-idrepo-0.eu.ds-idrepo-eu.prod.svc.clusterset.local:8989,ds-idrepo-0.us.ds-idrepo.prod.svc.clusterset.local:8989
-    # clusterTopology: "eu,us"
-    ## clusterIdentifier - current clusters identifier.  Must match 1 of the identifiers in clusterTopology
-    # clusterIdentifier: "eu"
-    ## Enable MCS(Googles Multi-cluster Services).  Not required for kubedns solution
-    # mcsEnabled: true


### PR DESCRIPTION
Add env spec to sample custom resource.
Remove cluster identifier and topology env vars.
Remove default advertised listen address.
Remove comments on alternative multi-cluster solutions.

ref: CLOUD-3347