### PR TITLE
chore: Add secret migration script, doc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 .PHONY: build install run test uninstall deploy manifest fmt vet generate docker-build release
 # Image URL to use all building/pushing image targets
 DEFAULT_IMG = gcr.io/engineering-devops/ds-operator
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-#CRD_OPTIONS ?= "crd:trivialVersions=false"
 # This will work on kube versions 1.16+. We want the CRD OpenAPI validation features in v1
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ CloudDNS:
 
 The operator supports two new Custom Resources:
 
-* [DirectoryBackup])(hack/ds-backup.yaml)
+* [DirectoryBackup](hack/ds-backup.yaml)
 * [DirectoryRestore](hack/ds-restore.yaml)
 
 These resources are used to create backups (tar, LDIF or dsbackup) and restore them again. Backup
@@ -328,7 +328,7 @@ format is preferred.
 
 ## Putting it all together
 
-A sample workflow to deploy a diretory server, backup that server, destroy the PVC, then restore the backup, would
+A sample workflow to deploy a directory server, backup that server, destroy the PVC, then restore the backup, would
 look like this:
 
 ```bash
@@ -355,6 +355,7 @@ kubctl scale directoryservice --all --replicas=2
 
 ## Changelog
 
+* v0.2.next - `spec.podTemplate.certificates` renamed to `spec.PodTemplate.secrets` to better reflect the purpose.
 * v0.2.0 - Add Support for Backup and Restore in LDIF, Tar and DSBackup formats.
  Migrate to cert-manager to issue PEM certificates for the directory server pods.
  Introduce a new common podTemplateSpec the Directory, Bacup and Restore Custom Resources.

--- a/hack/cp-sa-secret.sh
+++ b/hack/cp-sa-secret.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Sample script to migrate secret agent generated ds secrets to the tls format used by cert-manager
+# This can be used as a transition mechanism to reuse a saved secret agent secret.
+# After migration, the secret agent secrets should be deprecated in favour of cert-manager certs.
+
+D=/tmp/sa-secrets
+
+rm -fr $D
+mkdir -p $D
+
+# Get the DS and platform ca secrets
+kubectl get secret ds -o json >$D/ds-secret.json
+kubectl get secret platform-ca -o json >$D/ca.json
+
+# extract the base64 PEM certs
+jq <$D/ca.json -r  .data.'"ca.pem"' | base64 -d > $D/ca.pem
+jq <$D/ds-secret.json -r  .data.'"ssl-key-pair-private.pem"' | base64 -d > $D/ssl-private.pem
+jq <$D/ds-secret.json -r  .data.'"ssl-key-pair.pem"' | base64 -d > $D/ssl-keypair.pem
+
+
+
+cat >$D/ssl-tls.yaml <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ds-ssl-keypair
+type: kubernetes.io/tls
+data:
+  ca.crt: $(cat $D/ca.pem | base64 -w0)
+  tls.crt: $(cat $D/ssl-keypair.pem | base64 -w0)
+  tls.key: $(cat $D/ssl-private.pem | base64 -w0)
+EOF
+
+echo "Generated tls.yaml in $D."
+echo "apply with kubectl -f $D/ssl-tls.yaml"
+cat $D/ssl-tls.yaml
+
+# Uncomment if you want to do this automatically
+# kubectl apply -f $D/ssl-tls.yaml
+
+# Now create the ds master keypair
+jq <$D/ds-secret.json -r  .data.'"master-key-pair-private.pem"' | base64 -d > $D/master-private.pem
+jq <$D/ds-secret.json -r  .data.'"master-key-pair.pem"' | base64 -d > $D/master-keypair.pem
+
+cat >$D/master-tls.yaml <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ds-master-keypair
+type: kubernetes.io/tls
+data:
+  tls.crt: $(cat $D/master-keypair.pem | base64 -w0)
+  tls.key: $(cat $D/master-private.pem | base64 -w0)
+EOF
+
+echo ""
+echo "Generated $D/master-tls.yaml"
+echo "apply with kubectl -f $D/master-tls.yaml"
+cat $D/master-tls.yaml
+
+# Uncomment if you want to do this automatically
+# kubectl apply -f $D/master-tls.yaml


### PR DESCRIPTION
adds a script to convert existing secret agent secrets to the same format used by cert-manager.