### PR TITLE
refactor: Make directoryInstance field optional

### DIFF
--- a/api/v1alpha1/directoryservice_types.go
+++ b/api/v1alpha1/directoryservice_types.go
@@ -85,7 +85,7 @@ type DirectorySnapshotSpec struct {
 	// +kubebuilder:default:=10
 	SnapshotsRetained int32 `json:"snapshotsRetained,required"`
 	// +kubebuilder:default:=0
-	DirectoryInstance int32 `json:"directoryInstance,required"`
+	DirectoryInstance int32 `json:"directoryInstance,omitempty"`
 }
 
 // DirectoryPasswords is a reference to account secrets that contain passwords for the directory.

--- a/config/crd/bases/directory.forgerock.io_directoryservices.yaml
+++ b/config/crd/bases/directory.forgerock.io_directoryservices.yaml
@@ -448,7 +448,6 @@ spec:
                     format: int32
                     type: integer
                 required:
-                - directoryInstance
                 - enabled
                 - periodMinutes
                 - snapshotsRetained

--- a/hack/migration/ds.yaml
+++ b/hack/migration/ds.yaml
@@ -107,7 +107,7 @@ spec:
     # Keep this many snapshots. Older snapshots will be deleted
     snapshotsRetained: 3
     # DS instance to take snapshot of. Default is 0(ds-idrepo-0)
-    directoryInstance: 0
+    # directoryInstance: 1
 
   passwords:
       # uid=admin and uid=monitor are required account secrets.


### PR DESCRIPTION
Make directoryInstance field optional so it's backward compatible.

ref: CLOUD-3801