### PR TITLE
chore: Add new label and edit backup/restore pvc/volumesnapshot names.

### DIFF
--- a/controllers/job.go
+++ b/controllers/job.go
@@ -16,7 +16,7 @@ import (
 
 // Create a directory service job that can backup or restore data
 func createDSJob(ctx context.Context, client client.Client, scheme *runtime.Scheme, dataPVC *v1.PersistentVolumeClaim, backupPVC string,
-	podTemplate *directoryv1alpha1.DirectoryPodTemplate, args []string, owner metav1.Object) (*batch.Job, error) {
+	podTemplate *directoryv1alpha1.DirectoryPodTemplate, args []string, owner metav1.Object, kind string) (*batch.Job, error) {
 
 	var job batch.Job
 	log := k8slog.FromContext(ctx)
@@ -113,10 +113,11 @@ func createDSJob(ctx context.Context, client client.Client, scheme *runtime.Sche
 
 	_, err := ctrl.CreateOrUpdate(ctx, client, &job, func() error {
 		var err error
+		//var controllerName string
 		if job.CreationTimestamp.IsZero() {
 			log.V(8).Info("Creating job", "jobName", job.GetName())
 
-			job.ObjectMeta.Labels = createLabels(job.GetName(), nil)
+			job.ObjectMeta.Labels = createLabels(job.GetName(), kind, nil)
 			job.Spec = batch.JobSpec{
 				// Parallelism:             new(int32),
 				// Completions:             new(int32),

--- a/controllers/proxy.go
+++ b/controllers/proxy.go
@@ -100,7 +100,7 @@ func createDSProxyDeployment(ds *directoryv1alpha1.DirectoryService, deployment 
 	var forgerockUser int64 = 11111
 
 	proxyName := ds.Name + "-proxy"
-	labels := createLabels(proxyName, map[string]string{
+	labels := createLabels(proxyName, ds.Kind, map[string]string{
 		"app.kubernetes.io/component": "ds-proxy",
 	})
 

--- a/controllers/proxy_service.go
+++ b/controllers/proxy_service.go
@@ -70,7 +70,7 @@ func (r *DirectoryServiceReconciler) reconcileProxyService(ctx context.Context, 
 // Create the service for ds
 func createProxyService(ds *directoryv1alpha1.DirectoryService, svc *v1.Service) error {
 	proxyName := ds.Name + "-proxy"
-	labels := createLabels(proxyName, map[string]string{
+	labels := createLabels(proxyName, ds.Kind, map[string]string{
 		"app.kubernetes.io/component": "ds-proxy",
 	})
 	svcTemplate := v1.Service{

--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -34,7 +34,7 @@ func (r *DirectoryServiceReconciler) reconcilePVC(ctx context.Context, ds *direc
 			var err error
 			// does the pvc not exist yet?
 			if pvc.CreationTimestamp.IsZero() {
-				pvc.ObjectMeta.Labels = createLabels(ds.GetObjectMeta().GetName(), nil)
+				pvc.ObjectMeta.Labels = createLabels(ds.GetObjectMeta().GetName(), ds.Kind, nil)
 				// enables the volume to be writen by the forgerock user in the root group.
 				pvc.ObjectMeta.Annotations = map[string]string{
 					"pv.beta.kubernetes.io/gid": "0",

--- a/controllers/secrets.go
+++ b/controllers/secrets.go
@@ -30,9 +30,9 @@ func (r *DirectoryServiceReconciler) reconcileSecrets(ctx context.Context, ds *d
 			_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 				if secret.CreationTimestamp.IsZero() {
 					log.V(8).Info("Created Secret", "secret", secret.ObjectMeta.Name)
-					secret.ObjectMeta.Labels = createLabels(ds.Name, nil)
+					secret.ObjectMeta.Labels = createLabels(ds.Name, ds.Kind, nil)
 				}
-				if _, ok := secret.Data[accountSecret.Key]; ! ok {
+				if _, ok := secret.Data[accountSecret.Key]; !ok {
 					log.V(8).Info("Updating Secret", "secret", secret.ObjectMeta.Name)
 					secret.Data[accountSecret.Key] = []byte(randPassword(24))
 				}

--- a/controllers/service.go
+++ b/controllers/service.go
@@ -49,7 +49,7 @@ func (r *DirectoryServiceReconciler) reconcileService(ctx context.Context, ds *d
 func createService(ds *directoryv1alpha1.DirectoryService, svc *v1.Service) error {
 	svcTemplate := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:      createLabels(ds.Name, nil),
+			Labels:      createLabels(ds.Name, ds.Kind, nil),
 			Annotations: make(map[string]string),
 			Name:        svc.Name,
 			Namespace:   ds.Namespace,

--- a/controllers/snapshots.go
+++ b/controllers/snapshots.go
@@ -66,7 +66,7 @@ func (r *DirectoryServiceReconciler) reconcileSnapshots(ctx context.Context, ds 
 
 	var s = &snapshot.VolumeSnapshot{
 		ObjectMeta: v1.ObjectMeta{Name: snapName, Namespace: ds.GetNamespace(),
-			Labels:      createLabels(ds.GetName(), nil),
+			Labels:      createLabels(ds.GetName(), ds.Kind, nil),
 			Annotations: map[string]string{"directory.forgerock.io/lastSnapshotTime": strconv.Itoa(int(now))},
 		},
 		Spec: snapshot.VolumeSnapshotSpec{
@@ -137,7 +137,7 @@ func (r *DirectoryServiceReconciler) getSnapshotList(ctx context.Context, ds *di
 
 	log := k8slog.FromContext(ctx)
 	var snapshotList snapshot.VolumeSnapshotList
-	labels := createLabels(ds.GetName(), nil)
+	labels := createLabels(ds.GetName(), ds.Kind, nil)
 
 	// todo: Filter client.MatchingFields{jobOwnerKey: req.Name}
 	err := r.Client.List(ctx, &snapshotList, client.InNamespace(ds.GetNamespace()), client.MatchingLabels(labels))

--- a/controllers/sts.go
+++ b/controllers/sts.go
@@ -231,7 +231,7 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 	// Create a template
 	stemplate := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    createLabels(ds.Name, nil),
+			Labels:    createLabels(ds.Name, ds.Kind, nil),
 			Name:      ds.Name,
 			Namespace: ds.Namespace,
 		},
@@ -246,7 +246,7 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 			Replicas:    ds.Spec.Replicas,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: createLabels(ds.Name, nil),
+					Labels: createLabels(ds.Name, ds.Kind, nil),
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName: ds.Spec.PodTemplate.ServiceAccountName,
@@ -323,7 +323,7 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "data",
 						Namespace: ds.Namespace,
-						Labels:    createLabels(ds.Name, nil),
+						Labels:    createLabels(ds.Name, ds.Kind, nil),
 						Annotations: map[string]string{
 							"pv.beta.kubernetes.io/gid": "0",
 						},

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -19,11 +19,12 @@ func makeMeta(name, namespace string) metav1.ObjectMeta {
 // Add all the standard labels to the labels map, and return the new map
 // instanceName is the unique instance (ds-idrepo, ds-cts, etc.)
 // If the labels map is nil or empty, just return the standard labels
-func createLabels(instanceName string, labels map[string]string) map[string]string {
+func createLabels(instanceName string, controllerName string, labels map[string]string) map[string]string {
 	l := map[string]string{
 		"app.kubernetes.io/managed-by": "ds-operator",
 		"app.kubernetes.io/name":       LabelApplicationName,
 		"app.kubernetes.io/instance":   instanceName,
+		"app.kubernetes.io/controller": controllerName,
 		"app.kubernetes.io/part-of":    "forgerock",
 	}
 	if labels != nil {

--- a/hack/ds-backup.yaml
+++ b/hack/ds-backup.yaml
@@ -11,7 +11,7 @@ spec:
   # In this case, it applies to the DS Job that will run the backup.
   # The "backup" entrypoint will be called.
   podTemplate:
-    image:  us-docker.pkg.dev/forgeops-public/images/ds:7.2-dev
+    image:  us-docker.pkg.dev/forgeops-public/images/ds:dev
     imagePullPolicy: IfNotPresent
 
     # The spec for the volume that holds the backup. The volume name will be the same as our metadata.name (ds-backup in this case)
@@ -20,7 +20,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 512Mi
+          storage: 1Gi
 
     # Used for snapshot creation
     volumeSnapshotClassName: ds-snapshot-class

--- a/hack/ds-kustomize/ds.yaml
+++ b/hack/ds-kustomize/ds.yaml
@@ -18,7 +18,7 @@ spec:
   podTemplate:
     # The image must support the entry point hooks defined in the forgeops docker/ds/ds Dockerfile.
     # See https://github.com/ForgeRock/forgeops/tree/master/docker/ds/ds
-    image: us-docker.pkg.dev/forgeops-public/images/ds:7.2-dev
+    image: us-docker.pkg.dev/forgeops-public/images/ds:dev
     imagePullPolicy: IfNotPresent
     # The resources assigned to each DS pod
     resources:
@@ -47,7 +47,7 @@ spec:
     # You can add additional scripts in the configmap for adhoc commands that can be run
     # using kubectl exec.
     # Scripts are mounted on /opt/opendj/scripts
-    scriptConfigMapName: ds-script-config
+    # scriptConfigMapName: ds-script-config
 
     # The volume spec for the directory data. This is the same as the Kubernetes PVC volume spec.
     volumeClaimSpec:
@@ -55,7 +55,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 512Mi
+          storage: 1Gi
       # Optional: If the volume dataSource is provided *AND* the PVC does not yet exist, the directory PVCs will be
       # initialized from the contents of the snapshot. They will NOT be initialized from the setup script.
       #
@@ -107,7 +107,7 @@ spec:
   # You must be using a CSI volume driver. CSI drivers are now the default on GCP clusters.
   # For more information on CSI drivers, see: https://kubernetes.io/docs/concepts/storage/volumes/#csi
   snapshots:
-    enabled: true
+    enabled: false
     # Take a snapshot every N minutes. The number here is low for testing.
     # On a production cluster, you should set this to something higher (20-30 minutes).
     # Note that GCP snapshots are quota limited to 6 per hour per disk.

--- a/hack/ds-restore.yaml
+++ b/hack/ds-restore.yaml
@@ -13,7 +13,7 @@ spec:
   podTemplate:
     # The directory server binary that contains commands to import ldif or run dsbackup
     # The "restore" entrypoint is called in the Job
-    image:  us-docker.pkg.dev/forgeops-public/images/ds:7.2-dev
+    image:  us-docker.pkg.dev/forgeops-public/images/ds:dev
     imagePullPolicy: IfNotPresent
 
     # Spec for the pvc that will hold the restored data in DS JE format.
@@ -24,7 +24,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 512Mi
+          storage: 1Gi
 
     # The class to use when taking volume snapshots.
     # A snapshot named metadata.name will be created (ds-restore in this example)


### PR DESCRIPTION
Add new controller name label to help isolate resources for deletion.
Add "temp-" prefix to backup/restore temporary pvcs and volumesnapshots.

ref: CLOUD-3817