### PR TITLE
feat: Add support for envFrom for init and ds containers

### DIFF
--- a/api/v1alpha1/directoryservice_types.go
+++ b/api/v1alpha1/directoryservice_types.go
@@ -67,7 +67,9 @@ type DirectoryPodTemplate struct {
 	// Optional - if not provided no mount will be performed
 	ScriptConfigMapName string `json:"scriptConfigMapName,omitempty"`
 
-	Env []corev1.EnvVar `json:"env,omitempty"`
+	InitEnvFrom []corev1.EnvFromSource `json:"initEnvFrom,omitempty"`
+	Env         []corev1.EnvVar        `json:"env,omitempty"`
+	EnvFrom     []corev1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Name of the volumesnapshot class used in any snapshot operation
 	// +kubebuilder:validation:Required

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -166,9 +166,23 @@ func (in *DirectoryPodTemplate) DeepCopyInto(out *DirectoryPodTemplate) {
 	in.Resources.DeepCopyInto(&out.Resources)
 	out.Certificates = in.Certificates
 	in.VolumeClaimSpec.DeepCopyInto(&out.VolumeClaimSpec)
+	if in.InitEnvFrom != nil {
+		in, out := &in.InitEnvFrom, &out.InitEnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/config/crd/bases/directory.forgerock.io_directorybackups.yaml
+++ b/config/crd/bases/directory.forgerock.io_directorybackups.yaml
@@ -150,6 +150,39 @@ spec:
                       - name
                       type: object
                     type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   image:
                     description: Docker Image for the directory server.
                     type: string
@@ -170,6 +203,39 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      type: object
+                    type: array
+                  initEnvFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
                       type: object
                     type: array
                   resources:

--- a/config/crd/bases/directory.forgerock.io_directoryrestores.yaml
+++ b/config/crd/bases/directory.forgerock.io_directoryrestores.yaml
@@ -147,6 +147,39 @@ spec:
                       - name
                       type: object
                     type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   image:
                     description: Docker Image for the directory server.
                     type: string
@@ -167,6 +200,39 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      type: object
+                    type: array
+                  initEnvFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
                       type: object
                     type: array
                   resources:

--- a/config/crd/bases/directory.forgerock.io_directoryservices.yaml
+++ b/config/crd/bases/directory.forgerock.io_directoryservices.yaml
@@ -173,6 +173,39 @@ spec:
                       - name
                       type: object
                     type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                      type: object
+                    type: array
                   image:
                     description: Docker Image for the directory server.
                     type: string
@@ -193,6 +226,39 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
+                      type: object
+                    type: array
+                  initEnvFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
                       type: object
                     type: array
                   resources:

--- a/controllers/sts.go
+++ b/controllers/sts.go
@@ -187,6 +187,16 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 		envVars = append(envVars, ds.Spec.PodTemplate.Env...)
 	}
 
+	var initEnvFromSources []v1.EnvFromSource
+	if ds.Spec.PodTemplate.InitEnvFrom != nil {
+		initEnvFromSources = append(initEnvFromSources, ds.Spec.PodTemplate.InitEnvFrom...)
+	}
+
+	var envFromSources []v1.EnvFromSource
+	if ds.Spec.PodTemplate.EnvFrom != nil {
+		envFromSources = append(envFromSources, ds.Spec.PodTemplate.EnvFrom...)
+	}
+
 	startupProbe := v1.Probe{
 		Handler: v1.Handler{
 			HTTPGet: &v1.HTTPGetAction{
@@ -269,6 +279,7 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 							VolumeMounts:    volumeMounts,
 							Resources:       ds.DeepCopy().Spec.PodTemplate.Resources,
 							Env:             envVars,
+							EnvFrom:         initEnvFromSources,
 						},
 					},
 					Containers: []v1.Container{
@@ -281,6 +292,7 @@ func (r *DirectoryServiceReconciler) createDSStatefulSet(ctx context.Context, ds
 							Resources:       ds.DeepCopy().Spec.PodTemplate.Resources,
 							Ports:           containerPorts,
 							Env:             envVars,
+							EnvFrom:         envFromSources,
 							StartupProbe:    &startupProbe,
 						},
 					},

--- a/hack/ds-kustomize/ds.yaml
+++ b/hack/ds-kustomize/ds.yaml
@@ -80,6 +80,10 @@ spec:
     env:
     - name: "DS_TEST"
       value: "MY_TEST_VARIABLE"
+    initEnvFrom:
+    - secretRef:
+        name: ds-passwords
+
     # Examples of setting environment variables:
     #
     # 1. Set DS_BOOTSTRAP_REPLICATION_SERVERS to override the default bootstrap


### PR DESCRIPTION
The podTemplate now has two new fields:
* initEnvFrom: this field controls the envFrom for the init container
* envFrom: this field controls envFrom for the ds container

InitEnvFrom can be quite handy when trying to use secrets or configmap entries while the init container is priming the DS instance with the setup profile. Currently the only workaround is to use env with valueFrom and include each environment variable one-by-one, and that still means that these secrets/configmap entries are still available for the final ds containers as well.

Open questions:
* env currently specifies the environment for the init container and for the DS container at the same time, whilst initEnvFrom and envFrom are completely exclusive, should the init container pick up stuff from envFrom as well for example? (I definitely don't want to leak initEnvFrom into envFrom)
* it might seem now that initEnv is missing. For backwards compatibility reasons I can only assume that env will need to be picked up by the init container even if it is going to be implemented. Do you want me to add this?
* As I'm working for Identity Fusion, is there a way to attribute this work to them in some shape or form? Do you have any guidelines around this?